### PR TITLE
Fixed (ip:port) splitting after supporting ipv6 packets.

### DIFF
--- a/NodeClassifier/utils/featurizer.py
+++ b/NodeClassifier/utils/featurizer.py
@@ -4,7 +4,8 @@ from .pcap_utils import extract_macs, \
                        is_private, \
                        is_external, \
                        is_protocol, \
-                       get_source
+                       get_source, \
+                       get_ip_port
 import json
 
 def extract_features(session_dict, capture_source=None, max_port=None):
@@ -55,14 +56,8 @@ def extract_features(session_dict, capture_source=None, max_port=None):
     # Iterate over all sessions and aggregate the info
     other_ips = defaultdict(int)
     for key, session in session_dict.items():
-        splitter_index = key[0].rindex(':')
-        address_1 = key[0][0:splitter_index]
-        port_1 = key[0][splitter_index + 1:]
-
-        splitter_index = key[1].rindex(':')
-        address_2 = key[1][0:splitter_index]
-        port_2 = key[1][splitter_index + 1:]
-        
+        address_1, port_1 = get_ip_port(key[0])
+        address_2, port_2 = get_ip_port(key[1])
         
         # Get the first packet and grab the macs from it
         first_packet = session[0][1]

--- a/NodeClassifier/utils/pcap_utils.py
+++ b/NodeClassifier/utils/pcap_utils.py
@@ -69,8 +69,8 @@ def get_indiv_source(sessions, address_type='MAC'):
 
     # Count the incoming/outgoing sessions for all addresses
     for key in sessions:
-        source_address = key[0].split(':')[0]
-        destination_address = key[1].split(':')[0]
+        source_address, _ = get_ip_port(key[0])
+        destination_address, _ = get_ip_port(key[1])
 
         # Get the first packet and grab the macs from it
         first_packet = sessions[key][0][1]
@@ -275,8 +275,8 @@ def clean_session_dict(sessions, source_address=None):
     def clean_dict(sessions, source_address):
         cleaned_sessions = OrderedDict()
         for key, packets in sessions.items():
-            address_1, port_1 = key[0].split(':')
-            address_2, port_2 = key[1].split(':')
+            address_1, port_1 = get_ip_port(key[0])
+            address_2, port_2 = get_ip_port(key[1])
 
             first_packet = sessions[key][0][1]
             source_mac, destination_mac = extract_macs(first_packet)
@@ -341,10 +341,11 @@ def get_length(packet):
         length += pow(16,i)*hex_str.index(c)
     return length
 
+
 def featurize_session(key, packets, source=None):
     # Global session properties
-    address_1, port_1 = key[0].split(':')
-    address_2, port_2 = key[1].split(':')
+    address_1, port_1 = get_ip_port(key[0])
+    address_2, port_2 = get_ip_port(key[1])
     if address_1 == source or address_2 == source or source == None:
         initiated_by_source = None
         if address_1 == source:
@@ -400,3 +401,17 @@ def featurize_session(key, packets, source=None):
         return session_info
     else:
         return None
+
+
+def get_ip_port(socket_str):
+    """
+    Returns ip and port
+    :param socket_str: ipv4/6:port
+    :return:
+    address, port
+    """
+    splitter_index = socket_str.rindex(':')
+    address = socket_str[0:splitter_index]
+    port = socket_str[splitter_index + 1:]
+
+    return address, port


### PR DESCRIPTION
Fixed some codes where a colon `:` is used as a delimiter for spitting ip and port, and use a function which considers ipv6 address (has `:` in the ip part).